### PR TITLE
New feature: waitUntilInitialConfigLoadComplete()

### DIFF
--- a/core/src/test/java/com/medallia/merci/core/MerciTest.java
+++ b/core/src/test/java/com/medallia/merci/core/MerciTest.java
@@ -70,9 +70,8 @@ public class MerciTest {
         ConfigurationLoader loader = merci.createLoader(Duration.ofSeconds(10));
         loader.start();
 
-        Mockito.verify(executorService, Mockito.times(2)).scheduleWithFixedDelay(runnableCaptor.capture(), Matchers.anyLong(), Matchers.anyLong(), Matchers.any(TimeUnit.class));
+        Mockito.verify(executorService, Mockito.times(1)).scheduleWithFixedDelay(runnableCaptor.capture(), Matchers.anyLong(), Matchers.anyLong(), Matchers.any(TimeUnit.class));
         runnableCaptor.getAllValues().get(0).run();
-        runnableCaptor.getAllValues().get(1).run();
         Assert.assertEquals(ImmutableList.of("enable-all", "enable-none"), featureFlagManager.getConfigurationNames());
         Assert.assertEquals(ImmutableList.of("com.medallia.merci.core.configs.NumberConfig"), configManager.getConfigurationNames());
         Assert.assertEquals(2, featureFlagMetrics.getFeatureFlagUpdates());
@@ -154,9 +153,8 @@ public class MerciTest {
         ConfigurationLoader loader = merci.createLoader(Duration.ofSeconds(10));
         loader.start();
 
-        Mockito.verify(executorService, Mockito.times(2)).scheduleWithFixedDelay(runnableCaptor.capture(), Matchers.anyLong(), Matchers.anyLong(), Matchers.any(TimeUnit.class));
+        Mockito.verify(executorService, Mockito.times(1)).scheduleWithFixedDelay(runnableCaptor.capture(), Matchers.anyLong(), Matchers.anyLong(), Matchers.any(TimeUnit.class));
         runnableCaptor.getAllValues().get(0).run();
-        runnableCaptor.getAllValues().get(1).run();
         Assert.assertEquals(0, configurationLoaderMetrics.getConfigurationFailures());
         Assert.assertEquals(2, configurationLoaderMetrics.getConfigurationRequests());
         Assert.assertEquals(ImmutableList.of("enable-all", "enable-none"), featureFlagManager.getConfigurationNames());
@@ -200,9 +198,8 @@ public class MerciTest {
 
         merci.createAndStartLoader(Duration.ofSeconds(10));
 
-        Mockito.verify(executorService, Mockito.times(2)).scheduleWithFixedDelay(runnableCaptor.capture(), Matchers.anyLong(), Matchers.anyLong(), Matchers.any(TimeUnit.class));
+        Mockito.verify(executorService, Mockito.times(1)).scheduleWithFixedDelay(runnableCaptor.capture(), Matchers.anyLong(), Matchers.anyLong(), Matchers.any(TimeUnit.class));
         runnableCaptor.getAllValues().get(0).run();
-        runnableCaptor.getAllValues().get(1).run();
         Assert.assertEquals(0, configurationLoaderMetrics.getConfigurationFailures());
         Assert.assertEquals(2, configurationLoaderMetrics.getConfigurationRequests());
         Assert.assertEquals(ImmutableList.of("enable-all", "enable-none"), featureFlagManager.getConfigurationNames());
@@ -243,9 +240,8 @@ public class MerciTest {
         ConfigurationLoader loader = merci.createLoader(Duration.ofSeconds(10));
         loader.start();
 
-        Mockito.verify(executorService, Mockito.times(2)).scheduleWithFixedDelay(runnableCaptor.capture(), Matchers.anyLong(), Matchers.anyLong(), Matchers.any(TimeUnit.class));
+        Mockito.verify(executorService, Mockito.times(1)).scheduleWithFixedDelay(runnableCaptor.capture(), Matchers.anyLong(), Matchers.anyLong(), Matchers.any(TimeUnit.class));
         runnableCaptor.getAllValues().get(0).run();
-        runnableCaptor.getAllValues().get(1).run();
         Assert.assertEquals(1, configurationLoaderMetrics.getConfigurationFailures());
         Assert.assertEquals(2, configurationLoaderMetrics.getConfigurationRequests());
         Assert.assertEquals(ImmutableList.of("enable-all", "enable-none"), featureFlagManager.getConfigurationNames());


### PR DESCRIPTION
Provide a method in ConfigurationLoader which can be used to wait until the initial configuration load has been completed. This can be used to avoid race conditions during application startup.

For example, an application during its startup starts a background thread, and that background thread is going to do different things depending on the configuration. So the background thread wants to wait until the configuration is loaded, before actually doing anything dependent on the configuration. With this PR, assuming the background thread has access to the ConfigurationLoader object, it can call waitUntilInitialConfigLoadComplete() to wait until the initial attempt to load config has completed.

(Note that waitUntilInitialConfigLoadComplete() will return once the first attempt to load config has completed, whether or not that attempt was successful. This code is designed to prevent race conditions at startup, not to prevent issues due to temporary failure of some remote config service.)